### PR TITLE
Fixed alignment errors with gcc 8

### DIFF
--- a/grub-core/fs/btrfs.c
+++ b/grub-core/fs/btrfs.c
@@ -175,7 +175,7 @@ struct grub_btrfs_time
 {
   grub_int64_t sec;
   grub_uint32_t nanosec;
-} __attribute__ ((aligned (4)));
+} GRUB_PACKED;
 
 struct grub_btrfs_inode
 {

--- a/include/grub/efiemu/runtime.h
+++ b/include/grub/efiemu/runtime.h
@@ -29,7 +29,7 @@ struct grub_efiemu_ptv_rel
 
 struct efi_variable
 {
-  grub_efi_guid_t guid;
+  grub_efi_packed_guid_t guid;
   grub_uint32_t namelen;
   grub_uint32_t size;
   grub_efi_uint32_t attributes;

--- a/include/grub/gpt_partition.h
+++ b/include/grub/gpt_partition.h
@@ -28,7 +28,7 @@ struct grub_gpt_part_type
   grub_uint16_t data2;
   grub_uint16_t data3;
   grub_uint8_t data4[8];
-} __attribute__ ((aligned(8)));
+} GRUB_PACKED;
 typedef struct grub_gpt_part_type grub_gpt_part_type_t;
 
 #define GRUB_GPT_PARTITION_TYPE_EMPTY \


### PR DESCRIPTION
### Description
If I try to compile TrustedGRUB2 using make and gcc, I'll run into build errors.
### Current Behaviour
If I execute make, I'll get the following build error:
```
In file included from grub-core/disk/ldm.c:26:
./include/grub/gpt_partition.h:79:1: error: alignment 1 of ‘struct grub_gpt_partentry’ is less than 8 [-Werror=packed-not-aligned]
 } GRUB_PACKED;
 ^
```
### Expected Behaviour
I'm able to compile TrustedGRUB2 using make without any problems.
### System Informations
```
# gcc -v

Using built-in specs.
COLLECT_GCC=gcc
Thread model: posix
gcc version 8.1.1 20180712 (Red Hat 8.1.1-5) (GCC)
```